### PR TITLE
Initial commit

### DIFF
--- a/recipe/LICENSE.txt
+++ b/recipe/LICENSE.txt
@@ -1,0 +1,26 @@
+Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# (C) Copyright IBM Corp. 2018, 2020. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xeuo pipefail
+
+# Install the activate / deactivate scripts that set environment variables
+mkdir -p "${PREFIX}"/etc/conda/activate.d
+mkdir -p "${PREFIX}"/etc/conda/deactivate.d
+cp "${RECIPE_DIR}"/../scripts/activate.sh "${PREFIX}"/etc/conda/activate.d/activate-${PKG_NAME}.sh
+cp "${RECIPE_DIR}"/../scripts/deactivate.sh "${PREFIX}"/etc/conda/deactivate.d/deactivate-${PKG_NAME}.sh
+
+# Copy `nvcc` script to `bin` so it can be easily run.
+mkdir -p "${PREFIX}/bin"
+cp "${RECIPE_DIR}"/../scripts/nvcc "${PREFIX}/bin"
+
+if [[ ! -f "${CUDA_HOME}/lib64/stubs/libcuda.so" ]]
+then
+    echo "File ${CUDA_HOME}/lib64/stubs/libcuda.so doesn't exist"
+    return 1
+fi
+
+if ! grep -q "CUDA Version ${cudatoolkit%.*}" ${CUDA_HOME}/version.txt;
+then
+    echo "Version of installed CUDA didn't match package"
+    return 1
+fi
+
+# Add $(libcuda.so) shared object stub
+# Needed for things that want to link to $(libcuda.so).
+# Stub is used to avoid getting driver code linked into binaries
+mkdir -p "$PREFIX/lib/stubs"
+ln -s "${CUDA_HOME}/lib64/stubs/libcuda.so" "$PREFIX/lib/stubs/libcuda.so.1"

--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# (C) Copyright IBM Corp. 2018, 2020. All Rights Reserved.
+# (C) Copyright IBM Corp. 2020. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,15 +2,15 @@
 {% set number = 1 %}
 
 package:
-  name: nvcc
-  version: 10.2
+  name: {{ name }}
+  version: {{ cudatoolkit | replace(".*", "") }}
 
 build:
-  number: 1
+  number: {{ number }}
 
 outputs:
   - name: nvcc
-    number: 1
+    number: {{ number }}
     script: install_nvcc.sh
     build:
       script_env:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ build:
   number: {{ number }}
 
 outputs:
-  - name: nvcc
+  - name: {{ name }}_{{ target_platform }}
     number: {{ number }}
     script: install_nvcc.sh
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "nvcc" %}
+{% set number = 1 %}
+
+package:
+  name: nvcc
+  version: 10.2
+
+build:
+  number: 1
+
+outputs:
+  - name: nvcc
+    number: 1
+    script: install_nvcc.sh
+    build:
+      script_env:
+        - CUDA_HOME
+      ignore_run_exports:
+        - libgcc-ng
+      run_exports:
+        strong:
+          - cudatoolkit {{ cudatoolkit }}
+    requirements:
+      host:
+        # Needed to symlink libcuda into PREFIX libs.
+        - {{ compiler("c") }}
+      run:
+    test:
+      requires:
+        - {{ compiler("c") }}
+        # Host code is forwarded to a C++ compiler
+        - {{ compiler("cxx") }}
+      files:
+        - test.cu
+      commands:
+        - nvcc test.cu
+
+about:
+  home: https://github.com/conda-forge/nvcc-feedstock
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: A meta-package to enable the system nvcc
+  description: A meta-package to enable the system nvcc
+
+extra:
+  recipe-maintainers:
+    - open-ce/open-ce-dev-team

--- a/recipe/test.cu
+++ b/recipe/test.cu
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# *****************************************************************
+#
+# Licensed Materials - Property of IBM
+#
+# (C) Copyright IBM Corp. 2020. All Rights Reserved.
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+# *****************************************************************
+
+if [[ ! -z "${CFLAGS+x}" ]]
+then
+  export CFLAGS_CONDA_NVCC_BACKUP="${CFLAGS:-}"
+fi
+
+if [[ ! -z "${CPPFLAGS+x}" ]]
+then
+  export CPPFLAGS_CONDA_NVCC_BACKUP="${CPPFLAGS:-}"
+fi
+
+if [[ ! -z "${CXXFLAGS+x}" ]]
+then
+  export CXXFLAGS_CONDA_NVCC_BACKUP="${CXXFLAGS:-}"
+fi
+
+export CFLAGS="${CFLAGS} -I${CUDA_HOME}/include"
+export CPPFLAGS="${CPPFLAGS} -I${CUDA_HOME}/include"
+export CXXFLAGS="${CXXFLAGS} -I${CUDA_HOME}/include"

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
-# *****************************************************************
+# (C) Copyright IBM Corp. 2018, 2020. All Rights Reserved.
 #
-# Licensed Materials - Property of IBM
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# (C) Copyright IBM Corp. 2020. All Rights Reserved.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# US Government Users Restricted Rights - Use, duplication or
-# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
-#
-# *****************************************************************
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 if [[ ! -z "${CFLAGS+x}" ]]
 then

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -13,6 +13,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [[ -z "${CUDA_HOME}" ]]
+then
+  echo "CUDA_HOME is not set. Checking common places.."
+
+  if [[ -d "/usr/local/cuda" ]]
+  then
+     echo "/usr/local/cuda found."
+     export CUDA_HOME=/usr/local/cuda
+  elif [[ -d "/usr/local/cuda-10.2" ]]
+  then
+     echo "/usr/local/cuda-10.2 found."
+     export CUDA_HOME=/usr/local/cuda-10.2
+  else
+     echo "CUDA Toolkit not found."
+  fi
+fi
+
+if [[ ! -f "${CUDA_HOME}/bin/nvcc" ]]
+then
+    echo "NVCC not found. Please install the CUDA Toolkit locally and set the CUDA_HOME environment variable."
+fi
+
 if [[ ! -z "${CFLAGS+x}" ]]
 then
   export CFLAGS_CONDA_NVCC_BACKUP="${CFLAGS:-}"

--- a/scripts/deactivate.sh
+++ b/scripts/deactivate.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# *****************************************************************
+#
+# Licensed Materials - Property of IBM
+#
+# (C) Copyright IBM Corp. 2020. All Rights Reserved.
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+# *****************************************************************
+￼
+if [[ ! -z "${CFLAGS_CONDA_NVCC_BACKUP+x}" ]]
+then
+  export CFLAGS="${CFLAGS_CONDA_NVCC_BACKUP}"
+  unset CFLAGS_CONDA_NVCC_BACKUP
+fi
+
+if [[ ! -z "${CPPFLAGS_CONDA_NVCC_BACKUP+x}" ]]
+then
+  export CPPFLAGS="${CPPFLAGS_CONDA_NVCC_BACKUP}"
+  unset CPPFLAGS_CONDA_NVCC_BACKUP
+fi
+
+if [[ ! -z "${CXXFLAGS_CONDA_NVCC_BACKUP+x}" ]]
+then
+  export CXXFLAGS="${CXXFLAGS_CONDA_NVCC_BACKUP}"
+  unset CXXFLAGS_CONDA_NVCC_BACKUP
+fi

--- a/scripts/deactivate.sh
+++ b/scripts/deactivate.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
-# *****************************************************************
+# (C) Copyright IBM Corp. 2018, 2020. All Rights Reserved.
 #
-# Licensed Materials - Property of IBM
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# (C) Copyright IBM Corp. 2020. All Rights Reserved.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# US Government Users Restricted Rights - Use, duplication or
-# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
-#
-# *****************************************************************
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ￼
 if [[ ! -z "${CFLAGS_CONDA_NVCC_BACKUP+x}" ]]
 then

--- a/scripts/nvcc
+++ b/scripts/nvcc
@@ -1,0 +1,12 @@
+#!/bin/bash
+# *****************************************************************
+#
+# Licensed Materials - Property of IBM
+#
+# (C) Copyright IBM Corp. 2020. All Rights Reserved.
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+# *****************************************************************
+"${CUDA_HOME}/bin/nvcc" -ccbin "${CXX}" $@

--- a/scripts/nvcc
+++ b/scripts/nvcc
@@ -1,12 +1,16 @@
 #!/bin/bash
-# *****************************************************************
+# (C) Copyright IBM Corp. 2018, 2020. All Rights Reserved.
 #
-# Licensed Materials - Property of IBM
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# (C) Copyright IBM Corp. 2020. All Rights Reserved.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# US Government Users Restricted Rights - Use, duplication or
-# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
-# *****************************************************************
 "${CUDA_HOME}/bin/nvcc" -ccbin "${CXX}" $@


### PR DESCRIPTION
Initial checkin of the nvcc meta package.
The CUDA_HOME env var needs to be set for this to build. It does complain properly about it if not set.

A few things need some work. 
 - the bash activate/deactivate scripts complain
 - Need to test on a system without GPUs but CUDA still installed (ie systems with only a libcuda stub) to see if it works ok
 - Should this recipe have a run time dependency on `cudatoolkit`? Or perhaps we want to explicitly avoid that since this package will only be included at build time for other packages in which case it will use the locally installed CUDA.