### PR TITLE
Switch to use OPEN_CE_CUDA_HOME

### DIFF
--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -25,13 +25,13 @@ cp "${RECIPE_DIR}"/../scripts/deactivate.sh "${PREFIX}"/etc/conda/deactivate.d/d
 mkdir -p "${PREFIX}/bin"
 cp "${RECIPE_DIR}"/../scripts/nvcc "${PREFIX}/bin"
 
-if [[ ! -f "${CUDA_HOME}/lib64/stubs/libcuda.so" ]]
+if [[ ! -f "${OPEN_CE_CUDA_HOME}/lib64/stubs/libcuda.so" ]]
 then
-    echo "File ${CUDA_HOME}/lib64/stubs/libcuda.so doesn't exist"
+    echo "File ${OPEN_CE_CUDA_HOME}/lib64/stubs/libcuda.so doesn't exist"
     return 1
 fi
 
-if ! grep -q "CUDA Version ${cudatoolkit%.*}" ${CUDA_HOME}/version.txt;
+if ! grep -q "CUDA Version ${cudatoolkit%.*}" ${OPEN_CE_CUDA_HOME}/version.txt;
 then
     echo "Version of installed CUDA didn't match package"
     return 1
@@ -41,11 +41,11 @@ fi
 # Needed for things that want to link to $(libcuda.so).
 # Stub is used to avoid getting driver code linked into binaries
 mkdir -p "$PREFIX/lib/stubs"
-ln -s "${CUDA_HOME}/lib64/stubs/libcuda.so" "$PREFIX/lib/stubs/libcuda.so.1"
+ln -s "${OPEN_CE_CUDA_HOME}/lib64/stubs/libcuda.so" "$PREFIX/lib/stubs/libcuda.so.1"
 
 # These symlinks are needed in order for cmake to set the correct include
 # directories.
 mkdir -p "$PREFIX/include"
-ln -s "${CUDA_HOME}"/include/cuda_runtime.h "$PREFIX"/include/cuda_runtime.h
-ln -s "${CUDA_HOME}"/include/device_functions.h "$PREFIX"/include/device_functions.h
-ln -s "${CUDA_HOME}"/include/cuda.h "$PREFIX"/include/cuda.h
+ln -s "${OPEN_CE_CUDA_HOME}"/include/cuda_runtime.h "$PREFIX"/include/cuda_runtime.h
+ln -s "${OPEN_CE_CUDA_HOME}"/include/device_functions.h "$PREFIX"/include/device_functions.h
+ln -s "${OPEN_CE_CUDA_HOME}"/include/cuda.h "$PREFIX"/include/cuda.h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ outputs:
     script: install_nvcc.sh
     build:
       script_env:
-        - CUDA_HOME
+        - OPEN_CE_CUDA_HOME
       ignore_run_exports:
         - libgcc-ng
       run_exports:

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -13,26 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [[ -z "${CUDA_HOME}" ]]
+if [[ -z "${OPEN_CE_CUDA_HOME}" ]]
 then
-  echo "CUDA_HOME is not set. Checking common places.."
+  echo "OPEN_CE_CUDA_HOME is not set. Checking common places.."
 
   if [[ -d "/usr/local/cuda" ]]
   then
      echo "/usr/local/cuda found."
-     export CUDA_HOME=/usr/local/cuda
+     export OPEN_CE_CUDA_HOME=/usr/local/cuda
   elif [[ -d "/usr/local/cuda-10.2" ]]
   then
      echo "/usr/local/cuda-10.2 found."
-     export CUDA_HOME=/usr/local/cuda-10.2
+     export OPEN_CE_CUDA_HOME=/usr/local/cuda-10.2
   else
      echo "CUDA Toolkit not found."
   fi
 fi
 
-if [[ ! -f "${CUDA_HOME}/bin/nvcc" ]]
+if [[ ! -f "${OPEN_CE_CUDA_HOME}/bin/nvcc" ]]
 then
-    echo "NVCC not found. Please install the CUDA Toolkit locally and set the CUDA_HOME environment variable."
+    echo "NVCC not found. Please install the CUDA Toolkit locally and set the OPEN_CE_CUDA_HOME environment variable."
 fi
 
 if [[ ! -z "${CFLAGS+x}" ]]
@@ -50,6 +50,6 @@ then
   export CXXFLAGS_CONDA_NVCC_BACKUP="${CXXFLAGS:-}"
 fi
 
-export CFLAGS="${CFLAGS} -I${CUDA_HOME}/include"
-export CPPFLAGS="${CPPFLAGS} -I${CUDA_HOME}/include"
-export CXXFLAGS="${CXXFLAGS} -I${CUDA_HOME}/include"
+export CFLAGS="${CFLAGS} -I${OPEN_CE_CUDA_HOME}/include"
+export CPPFLAGS="${CPPFLAGS} -I${OPEN_CE_CUDA_HOME}/include"
+export CXXFLAGS="${CXXFLAGS} -I${OPEN_CE_CUDA_HOME}/include"

--- a/scripts/nvcc
+++ b/scripts/nvcc
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"${CUDA_HOME}/bin/nvcc" $@
+"${OPEN_CE_CUDA_HOME}/bin/nvcc" $@

--- a/scripts/nvcc
+++ b/scripts/nvcc
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"${OPEN_CE_CUDA_HOME}/bin/nvcc" $@
+"${OPEN_CE_CUDA_HOME}/bin/nvcc" $*

--- a/scripts/nvcc
+++ b/scripts/nvcc
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"${OPEN_CE_CUDA_HOME}/bin/nvcc" $*
+exec "${OPEN_CE_CUDA_HOME}/bin/nvcc" "$@"


### PR DESCRIPTION
This PR will switch the NVCC package to use and rely on the `OPEN_CE_CUDA_HOME` environment variable instead of the `CUDA_HOME` environment variable. The reasoning here is to avoid functional collisions with code that uses and relies on the `CUDA_HOME` environment variable. Such a case was seen in NCCL.

This should be safe as nothing else likely uses `OPEN_CE_CUDA_HOME`

Recipes will now need to use:
```
  - script_env:
          OPEN_CE_CUDA_HOME
```

This also changes the `nvcc` script to use `"$@"` instead of `$@` so that everything is passed in verbatim.